### PR TITLE
Add jrl-cmakemodules to provide CMake config scripts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cmake"]
+	path = cmake
+	url = https://github.com/jrl-umi3218/jrl-cmakemodules

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(sources
 
 set(target rs405cb)
 add_library(${target} SHARED ${sources})
-target_include_directories(${target} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/RS405CB>)
+target_include_directories(${target} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include> $<INSTALL_INTERFACE:include/RS405CB>)
 set_target_properties(${target} PROPERTIES EXPORT_NAME ${PROJECT_NAME})
 
 install(FILES ${headers} DESTINATION include/RS405CB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,17 @@
-cmake_minimum_required(VERSION 2.4)
-project(futabe_RS450CB)
+cmake_minimum_required(VERSION 3.1)
+
+set(PROJECT_NAME RS405CB)
+set(PROJECT_DESCRIPTION "A Futaba RS405CB servo motor library")
+set(PROJECT_URL https://github.com/isri-aist/futabe_RS450CB)
+set(PROJECT_USE_CMAKE_EXPORT TRUE)
+set(PROJECT_USE_KEYWORD_LINK_LIBRARIES TRUE)
+set(INSTALL_DOCUMENTATION OFF CACHE BOOL "")
+set(INSTALL_GENERATED_HEADERS OFF CACHE BOOL "")
+set(INSTALL_PKG_CONFIG_FILE OFF CACHE BOOL "")
+set(CXX_DISABLE_WERROR ON)
+
+include(cmake/base.cmake)
+project(${PROJECT_NAME} LANGUAGES CXX)
 
 set(headers
   serial_port.h
@@ -13,7 +25,9 @@ set(sources
 
 set(target rs405cb)
 add_library(${target} SHARED ${sources})
+target_include_directories(${target} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/RS405CB>)
+set_target_properties(${target} PROPERTIES EXPORT_NAME ${PROJECT_NAME})
 
-install(FILES ${headers} DESTINATION include)
-install(TARGETS ${target} DESTINATION lib)
+install(FILES ${headers} DESTINATION include/RS405CB)
+install(TARGETS ${target} EXPORT ${TARGETS_EXPORT_NAME} DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 


### PR DESCRIPTION
Allows to:
```cmake
find_package(RS405CB REQUIRED)
target_link_libraries(target PUBLIC RS405CB::RS405CB)
```

It also installs the headers to the `RS405CB` subfolder but for compatibility with existing code it adds that folder to the include path.